### PR TITLE
UI tweaks: big camera button, informational text on preview screen

### DIFF
--- a/app/src/main/java/com/hackthegap/additonthefly/ImagePreviewActivity.java
+++ b/app/src/main/java/com/hackthegap/additonthefly/ImagePreviewActivity.java
@@ -164,9 +164,9 @@ public class ImagePreviewActivity extends AppCompatActivity {
     }
 
     private String dateFixer(){
-        String date = mDateField.getText().toString();
+        String dateA = mDateField.getText().toString();
 
-        String day = date.substring(0, date.indexOf("/") + 1);
+        String day = dateA.substring(0, dateA.indexOf("/") + 1);
         String dayDone;
         if (day.length() == 1) {
             dayDone = "0" + day;

--- a/app/src/main/java/com/hackthegap/additonthefly/MainActivity.java
+++ b/app/src/main/java/com/hackthegap/additonthefly/MainActivity.java
@@ -6,10 +6,10 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.support.design.widget.FloatingActionButton;
 import android.support.v4.content.FileProvider;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
-import android.widget.Button;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,7 +18,7 @@ import java.util.Date;
 
 public class MainActivity extends AppCompatActivity {
 
-    private Button mTakePhotoButton;
+    private FloatingActionButton mTakePhotoButton;
     static final int REQUEST_IMAGE_CAPTURE = 1;
 
     String mCurrentPhotoPath;
@@ -79,7 +79,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        mTakePhotoButton = (Button) findViewById(R.id.takeAPhotoButton);
+        mTakePhotoButton = (FloatingActionButton) findViewById(R.id.takeAPhotoButton);
         mTakePhotoButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/app/src/main/res/drawable/ic_photo_camera.xml
+++ b/app/src/main/res/drawable/ic_photo_camera.xml
@@ -1,0 +1,5 @@
+<vector android:height="100dp" android:viewportHeight="24.0"
+    android:viewportWidth="24.0" android:width="100dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFF" android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0"/>
+    <path android:fillColor="#FFFF" android:pathData="M9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2L9,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+</vector>

--- a/app/src/main/res/layout/activity_image_preview.xml
+++ b/app/src/main/res/layout/activity_image_preview.xml
@@ -12,6 +12,13 @@
         android:layout_width="300dp"
         android:layout_height="150dp" />
 
+    <TextView
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="Please inspect the following information and correct any if necessary."
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
     <RelativeLayout
         android:layout_marginStart="16dp"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,11 +6,14 @@
     android:layout_height="match_parent"
     tools:context="com.hackthegap.additonthefly.MainActivity">
 
-    <Button
+    <android.support.design.widget.FloatingActionButton
         android:id="@+id/takeAPhotoButton"
         android:layout_centerInParent="true"
         android:text="Take a photo"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:src="@drawable/ic_photo_camera"
+        app:fabSize="normal"
+        android:scaleType="center"
+        android:layout_width="200dp"
+        android:layout_height="200dp" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <dimen name="design_fab_size_normal" tools:override="true">150dp</dimen>
+    <dimen name="design_fab_size_mini" tools:override="true">30dp</dimen>
+</resources>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9331335/34646761-85b47ede-f336-11e7-9222-ff3684458816.png)

Basically replacing the "take a photo" button with a nice camera icon, and added some informational text to "inspect the information" before adding them to the calendar.

Please make sure you `git checkout` the branch and build it first and that it runs, before you merge this @yetterka.
  